### PR TITLE
Added buffer-concat and content-length streams

### DIFF
--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const ContentLengthStream = require('./streams/content-length-stream');
 const EventEmitter = require('events').EventEmitter;
 const stream = require('stream');
 const parseLinkHeader = require('parse-link-header');
@@ -53,15 +54,12 @@ module.exports = class Fragment extends EventEmitter {
     }
 
     onResponse (response) {
-        let contentSize = 0;
         if (response.statusCode >= 500) {
             this.emit('error', new Error('Internal Server Error'));
             this.stream.end();
             return;
         }
         this.emit('response', response.statusCode, response.headers);
-        response.on('data', (chunk) => contentSize += chunk.length);
-        response.on('end', () => this.emit('end', contentSize));
         this.links = parseLinkHeader([response.headers.link, response.headers['x-amz-meta-link']].join(','));
         if (this.attributes.async) {
             this.stream.write(`<div style="display:none;" id="async-${this.attributes.id}">`);
@@ -71,18 +69,20 @@ module.exports = class Fragment extends EventEmitter {
                 this.stream.write(`<div id="${this.attributes.id}">`);
             }
         }
-        response.pipe(this.stream, {end: false});
-        response.on('end', () => {
-            if (!this.attributes.inline) {
-                this.stream.write('</div>');
-                if (this.attributes.async) {
-                    this.initAsyncScript();
-                } else {
-                    this.initScript();
+        response
+            .pipe(new ContentLengthStream((contentLength) => {
+                this.emit('end', contentLength);
+                if (!this.attributes.inline) {
+                    this.stream.write('</div>');
+                    if (this.attributes.async) {
+                        this.initAsyncScript();
+                    } else {
+                        this.initScript();
+                    }
                 }
-            }
-            this.stream.end();
-        });
+                this.stream.end();
+            }))
+            .pipe(this.stream, {end: false});
     }
 
     insertLinks () {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,8 +1,8 @@
 'use strict';
 const AsyncStream = require('./streams/async-stream');
 const Fragment = require('./fragment');
-const PassThroughStream = require('stream').PassThrough;
 const StringifierStream = require('./streams/stringifier-stream');
+const ContentLengthStream = require('./streams/content-length-stream');
 const FRAGMENT_EVENTS = ['start', 'response', 'end', 'error', 'timeout'];
 
 module.exports = function processRequest (options, request, response) {
@@ -22,7 +22,6 @@ module.exports = function processRequest (options, request, response) {
         return {};
     });
     const forceSmartPipe = options.forceSmartPipe(request);
-    const resultStream = new PassThroughStream();
     const templatePromise = fetchTemplate(request, parseTemplate);
 
     let shouldWriteHead = true;
@@ -30,7 +29,7 @@ module.exports = function processRequest (options, request, response) {
 
     contextPromise.then((context) => {
 
-        const templateStream = new StringifierStream((tag) => {
+        const resultStream = new StringifierStream((tag) => {
 
             if (!tag.name && !tag.closingTag) {
                 // end of body tag
@@ -60,23 +59,18 @@ module.exports = function processRequest (options, request, response) {
                 }
                 fragment.on('response', (statusCode, headers) => {
                     if (fragment.attributes.id === primaryId) {
-                        this.emit('response', request, statusCode, {
+                        const responseHeaders = {
                             'Content-Type': 'text/html',
                             'Location': headers.location
-                        });
-                        response.writeHead(
-                            statusCode,
-                            {
-                                'Content-Type': 'text/html',
-                                'Location': headers.location
-                            }
-                        );
-                        let contentLength = 0;
-                        resultStream.on('data', (chunk) => contentLength += chunk.length);
-                        resultStream.on('end', () => {
-                            this.emit('end', request, contentLength);
-                        });
-                        resultStream.pipe(response);
+                        };
+                        this.emit('response', request, statusCode, responseHeaders);
+                        response.writeHead(statusCode, responseHeaders);
+                        resultStream
+                            .pipe(new ContentLengthStream((contentLength) => {
+                                this.emit('end', request, contentLength);
+                            }))
+                            .pipe(response);
+
                     }
                 });
                 fragment.on('error', (err) => {
@@ -94,24 +88,23 @@ module.exports = function processRequest (options, request, response) {
             return handleTag(tag);
         });
 
-        templateStream.on('finish', () => {
+        resultStream.on('finish', () => {
             asyncStream.end();
             if (shouldWriteHead) {
                 shouldWriteHead = false;
                 this.emit('response', request, 200, {'Content-Type': 'text/html'});
                 response.writeHead(200, {'Content-Type': 'text/html'});
-                let contentLength = 0;
-                resultStream.on('data', (chunk) => contentLength += chunk.length);
-                resultStream.on('end', () => {
-                    this.emit('end', request, contentLength);
-                });
-                resultStream.pipe(response);
+                resultStream
+                    .pipe(new ContentLengthStream((contentLength) => {
+                        this.emit('end', request, contentLength);
+                    }))
+                    .pipe(response);
             }
         });
 
-        templateStream.on('error', (err) => {
+        resultStream.on('error', (err) => {
             this.emit('template:error', request, err);
-            resultStream.unpipe(); // in case we output something
+            resultStream.unpipe();  // in case we output something
             if (shouldWriteHead) {
                 shouldWriteHead = false;
                 response.writeHead(500, {'Content-Type': 'text/plain'});
@@ -122,12 +115,12 @@ module.exports = function processRequest (options, request, response) {
         templatePromise
             .then((template) => {
                 template.on('error', (err) => {
-                    templateStream.emit('error', err);
+                    resultStream.emit('error', err);
                 });
-                template.pipe(templateStream).pipe(resultStream);
+                template.pipe(resultStream);
             })
             .catch((err) => {
-                templateStream.emit('error', err);
+                resultStream.emit('error', err);
             });
     });
 };

--- a/lib/streams/async-stream.js
+++ b/lib/streams/async-stream.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const stream = require('stream');
+const BufferConcatStream = require('./buffer-concat-stream');
 
 module.exports = class AsyncStream extends stream.Transform {
 
@@ -10,18 +11,14 @@ module.exports = class AsyncStream extends stream.Transform {
     }
 
     _transform (st, encoding, done) {
-        let data = new Buffer([]);
         this.streams += 1;
-        st.on('data', (chunk) => {
-            data = Buffer.concat([data, chunk]);
-        });
-        st.on('end', () => {
+        st.pipe(new BufferConcatStream ((data) => {
             this.streams -= 1;
             this.push(data);
             if (this.streams === 0) {
                 this.emit('alldone');
             }
-        });
+        }));
         st.on('error', (err) => {
             this.streams -= 1;
             this.emit('error', err);

--- a/lib/streams/buffer-concat-stream.js
+++ b/lib/streams/buffer-concat-stream.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const stream = require('stream');
+
+module.exports = class BufferConcatStream extends stream.Writable {
+
+    constructor (callback) {
+        super();
+        this.data = [];
+        this.on('finish', () => {
+            callback(Buffer.concat(this.data));
+        });
+    }
+
+    _write (chunk, encoding, done) {
+        this.data.push(chunk);
+        done(null, chunk);
+    }
+
+};

--- a/lib/streams/content-length-stream.js
+++ b/lib/streams/content-length-stream.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const stream = require('stream');
+
+module.exports = class ContentLengthStream extends stream.Transform {
+
+    constructor (callback) {
+        super();
+        this.callback = callback;
+        this.contentSize = 0;
+    }
+
+    _transform (chunk, encoding, done) {
+        this.contentSize += chunk.length;
+        done(null, chunk);
+    }
+
+    _flush (done) {
+        this.callback(this.contentSize);
+        done();
+    }
+
+};

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "node-tailor"
   ],
   "scripts": {
-    "test": "mocha --harmony tests",
-    "coverage": "node --harmony node_modules/.bin/istanbul cover _mocha -- tests",
+    "test": "mocha --harmony tests/**",
+    "coverage": "node --harmony node_modules/.bin/istanbul cover _mocha -- tests/**",
     "lint": "eslint lib/ tests/",
     "example": "node --harmony example/tailor"
   },

--- a/tests/streams/async-stream.js
+++ b/tests/streams/async-stream.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const stream = require('stream');
-const AsyncStream = require('../lib/streams/async-stream');
+const AsyncStream = require('../../lib/streams/async-stream');
 
 describe('Async Stream', () => {
 

--- a/tests/streams/buffer-concat-stream.js
+++ b/tests/streams/buffer-concat-stream.js
@@ -1,0 +1,16 @@
+'use strict';
+const assert = require('assert');
+const BufferConcatStream = require('../../lib/streams/buffer-concat-stream');
+
+describe('BufferConcatStream', () => {
+
+    it('concats the input and calls the callback with the result', (done) => {
+        const st = new BufferConcatStream((result) => {
+            assert(result.toString(), 'foobar');
+            done();
+        });
+        st.write(new Buffer('foo'));
+        st.end(new Buffer('bar'));
+    });
+
+});

--- a/tests/streams/content-length-stream.js
+++ b/tests/streams/content-length-stream.js
@@ -1,0 +1,32 @@
+'use strict';
+const assert = require('assert');
+const ContentLengthStream = require('../../lib/streams/content-length-stream');
+const Transform = require('stream').Transform;
+
+describe('ContentLengthStream', () => {
+
+    it('calculates content length and calls callback with the result', (done) => {
+        const st = new ContentLengthStream((contentLength) => {
+            assert(contentLength, 'foobar'.length);
+            done();
+        });
+        st.write(new Buffer('foo'));
+        st.end(new Buffer('bar'));
+    });
+
+    it('is a Transform stream', () => {
+        const st = new ContentLengthStream(() => {});
+        assert(st instanceof Transform);
+    });
+
+    it('passes through data chunks', (done) => {
+        const chunk = new Buffer('foo');
+        const st = new ContentLengthStream(() => {});
+        st.on('data', (data) => {
+            assert.equal(data, chunk);
+            done();
+        });
+        st.write(chunk);
+    });
+
+});

--- a/tests/streams/layout-streams.js
+++ b/tests/streams/layout-streams.js
@@ -1,8 +1,8 @@
 'use strict';
 const PassThrough = require('stream').PassThrough;
 const assert = require('assert');
-const ParserStream = require('../lib/streams/parser-stream');
-const StringifierStream = require('../lib/streams/stringifier-stream');
+const ParserStream = require('../../lib/streams/parser-stream');
+const StringifierStream = require('../../lib/streams/stringifier-stream');
 const lazypipe = require('lazypipe');
 
 


### PR DESCRIPTION
I got rid of manually handling `.on('data'..` events where possible by introducing `ContentLengthStream` and `BufferConcatStream`. I also got rid of additional `PassThrough` for the stringifier output.