### PR TITLE
Set tags before which the pipe should be inserted

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ module.exports = class Tailor extends EventEmitter {
             pipeInstanceName : () => '_p' + Math.round(Math.random() * 999)
         }, options);
         requestOptions.parseTemplate = parseTemplate(
-            [requestOptions.fragmentTag].concat(requestOptions.handledTags)
+            [requestOptions.fragmentTag].concat(requestOptions.handledTags),
+            ['script', requestOptions.fragmentTag]
         );
         this.requestHandler = requestHandler.bind(this, requestOptions);
         // To Prevent from exiting the process - https://nodejs.org/api/events.html#events_error_events

--- a/lib/streams/parser-stream.js
+++ b/lib/streams/parser-stream.js
@@ -32,8 +32,9 @@ function serializeTag (tag) {
 
 module.exports = class ParserStream extends stream.Transform {
 
-    constructor (optionalSpecialTags) {
+    constructor (optionalSpecialTags, optionalInsertPipeBeforeTags) {
         super({objectMode: true});
+        const insertPipeBeforeTags = optionalInsertPipeBeforeTags || [];
         const specialTags = optionalSpecialTags || [];
         const selfClosingTags = selfClosingBaseTags.concat(specialTags);
         let buffer = '';
@@ -50,7 +51,7 @@ module.exports = class ParserStream extends stream.Transform {
 
         Object.assign(this.parser, {
             onopentag: (tag) => {
-                if (tag.name === 'script' && !insertPipe) {
+                if (!insertPipe && ~insertPipeBeforeTags.indexOf(tag.name)) {
                     pushBuffer();
                     this.push({placeholder: 'pipe'});
                     insertPipe = true;
@@ -58,10 +59,6 @@ module.exports = class ParserStream extends stream.Transform {
                 if (~specialTags.indexOf(tag.name)) {
                     try {
                         pushBuffer();
-                        if (!insertPipe) {
-                            this.push({placeholder: 'pipe'});
-                            insertPipe = true;
-                        }
                         this.push(tag);
                     } catch (err) {
                         this.emit('error', err);


### PR DESCRIPTION
We should insert pipe definition before the fist fragment or the first script tag.