### PR TITLE
Increase listeners for concurrent handlers on stream

### DIFF
--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -23,6 +23,7 @@ module.exports = class StringifierStream extends stream.Transform {
         }
         let st = this.queue.shift();
         if (st instanceof stream) {
+            st.setMaxListeners(st.getMaxListeners() + 1);
             this.isBusy = true;
 
             const onData = (data) => {
@@ -44,6 +45,7 @@ module.exports = class StringifierStream extends stream.Transform {
                 st.removeListener('data', onData);
                 st.removeListener('end', onEnd);
                 st.removeListener('error', onError);
+                st.setMaxListeners(st.getMaxListeners() - 1);
             };
 
             st.on('data', onData);


### PR DESCRIPTION
`Warning: Possible EventEmitter memory leak detected. 11 data listeners added. Use emitter.setMaxListeners() to increase limit`.

Addresses this error, by keeping the listeners in control. This will make sure we get error message if an actual leak occurred. 