### PR TITLE
add missing break in example

### DIFF
--- a/example/fragment.js
+++ b/example/fragment.js
@@ -29,6 +29,7 @@ module.exports = (fragmentName, fragmentUrl) => (request, response) => {
                     background-color: lightgrey;
                 }
             `);
+            break;
         default:
             // serve fragment's body
             response.writeHead(200, {


### PR DESCRIPTION
Small change but when break is missing causes issues when trying to convert example to pull css from files.