### PR TITLE
introduce unnamed slot behaviour

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -83,8 +83,9 @@ module.exports = class CustomSerializer extends Serializer {
             if (slots) {
                 slots.forEach(this._serializeNode);
             }
+        } else if (this.defaultSlotsInserted) {
+            console.warn('Encountered duplicate Unnamed slots in the template - Skipping the node');
         } else {
-            // Unnamed slot behaviour
             const defaultSlots = this.slotMap.get('default');
             this.defaultSlotsInserted = true;
             if (defaultSlots) {

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -12,6 +12,7 @@ module.exports = class CustomSerializer extends Serializer {
         this.lastChildInserted = false;
         this.serializedList = [];
         this._serializeNode = this._serializeNode.bind(this);
+        this.defaultSlotsInserted = false;
     }
 
     pushBuffer() {
@@ -77,10 +78,17 @@ module.exports = class CustomSerializer extends Serializer {
 
     _serializeSlot(node) {
         const slotName = node.attribs.name;
-        if (this.slotMap.has(slotName)) {
+        if (slotName && this.slotMap.has(slotName)) {
             const slots = this.slotMap.get(slotName);
             if (slots) {
                 slots.forEach(this._serializeNode);
+            }
+        } else {
+            // Unnamed slot behaviour
+            const defaultSlots = this.slotMap.get('default');
+            this.defaultSlotsInserted = true;
+            if (defaultSlots) {
+                defaultSlots.forEach(this._serializeNode);
             }
         }
     }
@@ -94,9 +102,11 @@ module.exports = class CustomSerializer extends Serializer {
 
     _serializeRest() {
         this.lastChildInserted = true;
-        const defaultSlots = this.slotMap.get('default');
-        if (defaultSlots) {
-            defaultSlots.forEach(this._serializeNode);
+        if (!this.defaultSlotsInserted) {
+            const defaultSlots = this.slotMap.get('default');
+            if (defaultSlots) {
+                defaultSlots.forEach(this._serializeNode);
+            }
         }
         this.pushBuffer();
         this.serializedList.push({ placeholder: 'async' });

--- a/tests/tailor.js
+++ b/tests/tailor.js
@@ -614,10 +614,7 @@ describe('Tailor', () => {
                 '</body>'
             );
 
-        mockChildTemplate
-            .returns(
-                '<script src=""></script>'
-            );
+        mockChildTemplate.returns('<h1>hello</h1>');
 
         http.get('http://localhost:8080/test', (response) => {
             let data = '';
@@ -629,13 +626,24 @@ describe('Tailor', () => {
                     '<html>' +
                     '<head></head>' +
                     '<body>' +
-                    '<script src=""></script>' +
+                    '<h1>hello</h1>' +
                     '<h2>blah</h2>' +
                     '</body>' +
                     '</html>'
                 );
                 done();
             });
+        });
+    });
+
+    it('should warn if there are duplicate unnamed slots', (done) => {
+        sinon.stub(console, 'warn');
+        mockTemplate.returns('<slot></slot><slot></slot>');
+
+        http.get('http://localhost:8080/test', () => {
+            assert.equal(console.warn.callCount, 1);
+            console.warn.restore();
+            done();
         });
     });
 

--- a/tests/tailor.js
+++ b/tests/tailor.js
@@ -531,7 +531,7 @@ describe('Tailor', () => {
         });
     });
 
-    it('should support partial templates using slots', (done) => {
+    it('should support base templates using slots', (done) => {
         mockTemplate
             .returns(
                 '<head>' +
@@ -595,6 +595,42 @@ describe('Tailor', () => {
                     '<body>' +
                     '<script src=""></script>' +
                     '<h2>Last</h2>' +
+                    '</body>' +
+                    '</html>'
+                );
+                done();
+            });
+        });
+    });
+
+    it('should insert default slots if unnamed slot is present in parent template', (done) => {
+        mockTemplate
+            .returns(
+                '<head>' +
+                '</head>' +
+                '<body>' +
+                '<slot></slot>' +
+                '<h2>blah</h2>' +
+                '</body>'
+            );
+
+        mockChildTemplate
+            .returns(
+                '<script src=""></script>'
+            );
+
+        http.get('http://localhost:8080/test', (response) => {
+            let data = '';
+            response.on('data', (chunk) => {
+                data += chunk;
+            });
+            response.on('end', () => {
+                assert.equal(data,
+                    '<html>' +
+                    '<head></head>' +
+                    '<body>' +
+                    '<script src=""></script>' +
+                    '<h2>blah</h2>' +
                     '</body>' +
                     '</html>'
                 );


### PR DESCRIPTION
This will allow us to insert contents anywhere in the parent template without ugly slot name magic in the child templates. 