### PR TITLE
adding helper function to inject a template for root path

### DIFF
--- a/example/tailor.js
+++ b/example/tailor.js
@@ -4,10 +4,14 @@ const path = require('path');
 const Tailor = require('../index');
 const fetchTemplateFs = require('../lib/fetch-template');
 const serveFragment = require('./fragment');
+const injectRootTemplate = require('../lib/inject-root-template');
 const baseTemplateFn = () => 'base-template';
 
+const templatesHandler = fetchTemplateFs(path.join(__dirname, 'templates'), baseTemplateFn);
+const templates = injectRootTemplate('index', templatesHandler);
+
 const tailor = new Tailor({
-    fetchTemplate: fetchTemplateFs(path.join(__dirname, 'templates'), baseTemplateFn)
+    fetchTemplate: templates
 });
 const server = http.createServer((req, res) => {
     if (req.url === '/favicon.ico') {

--- a/lib/inject-root-template.js
+++ b/lib/inject-root-template.js
@@ -1,0 +1,33 @@
+/**
+ * A wrapper to inject a template as root template.
+ */
+
+
+'use strict';
+
+
+/**
+ * MODULES.
+ */
+const url = require('url');
+
+
+/**
+ * FUNCTION.
+ */
+const injectRootTemplate = (rootTemplate, handler) => {
+    return (request, parseTemplate) => {
+        const urlObj = url.parse(request.url, true);
+        if (urlObj.pathname.length === 1) {
+            urlObj.pathname = rootTemplate;
+        }
+        request.url = url.format(urlObj);
+        return handler(request, parseTemplate);
+    };
+};
+
+
+/**
+ * EXPORTS.
+ */
+module.exports = injectRootTemplate;


### PR DESCRIPTION
I haven't not yet worked with tailor more than the example, but as mentioned in #55 it can be confusing that the example is not listening on the root path. I do not know whether this feature is a valid use-case for production ready tailor use, but for the example it helps injecting a template that is used for the "/" path.
It also does not break any legacy implementations as "inject-root-template.js" wraps around "fetch-template.js".