### PR TITLE
configurable options for headers & refactoring [fixes #91, 104]

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,18 @@ server.listen(process.env.PORT || 8080);
 
 ## Options
 
-* `fetchContext(request)` a function that returns a promise of the context, that is an object that maps fragment id to fragment url, to be able to override urls of the fragments on the page, defaults to `Promise.resolve({})`
-* `fetchTemplate(request, parseTemplate)` a function that should fetch the template, call `parseTemplate` and return a promise of the result. Useful to implement your own way to retrieve and cache the templates, e.g. from s3.
+* `fetchContext(request)` - Function that returns a promise of the context, that is an object that maps fragment id to fragment url, to be able to override urls of the fragments on the page, defaults to `Promise.resolve({})`
+* `fetchTemplate(request, parseTemplate)` - Function that should fetch the template, call `parseTemplate` and return a promise of the result. Useful to implement your own way to retrieve and cache the templates, e.g. from s3.
 Default implementation [`lib/fetch-template.js`](https://github.com/zalando/tailor/blob/master/lib/fetch-template.js) fetches the template from  the file system
-* `fragmentTag` a name of the fragment tag, defaults to `fragment`
-* `handledTags` an array of custom tags, check [`tests/handle-tag`](https://github.com/zalando/tailor/blob/master/tests/handle-tag.js) for more info
-* `handleTag(request, tag)` receives a tag or closing tag and serializes it to a string or returns a stream
-* `requestFragment(url, fragmentAttributes, request)` a function that returns a promise of request to a fragment server, check the default implementation in [`lib/request-fragment`](https://github.com/zalando/tailor/blob/master/lib/request-fragment.js)
+* `templatesPath` - To specify the path where the templates are stored locally, Defaults to `/templates/`
+* `fragmentTag` - Name of the fragment tag, defaults to `fragment`
+* `handledTags` - An array of custom tags, check [`tests/handle-tag`](https://github.com/zalando/tailor/blob/master/tests/handle-tag.js) for more info
+* `handleTag(request, tag)` - Receives a tag or closing tag and serializes it to a string or returns a stream
+* `filterHeaders(attributes, request)` - Function that filters the request headers that are passed to fragment request, check default implementation in [`lib/filter-headers`](https://github.com/zalando/tailor/blob/master/lib/filter-headers.js)
+* `requestFragment(filterHeaders)(url, attributes, request)` - Function that returns a promise of request to a fragment server, check the default implementation in [`lib/request-fragment`](https://github.com/zalando/tailor/blob/master/lib/request-fragment.js)
 * `amdLoaderUrl` - URL to AMD loader. We use [RequireJS from cdnjs](https://cdnjs.com/libraries/require.js) as deafult
+* `pipeInstanceName` - Pipe instance name that is available in the browser window for consuming frontend hooks.
+* `pipeAttributes(attributes)` - Function that returns the minimal set of fragment attributes available on the frontend [hooks](https://github.com/zalando/tailor/blob/master/docs/hooks.md).
 
 # Template
 

--- a/lib/filter-headers.js
+++ b/lib/filter-headers.js
@@ -5,15 +5,19 @@ const ACCEPT_HEADERS = ['accept-language', 'referer', 'user-agent'];
  * @callback filterHeaders
  *
  * @param {Object} attributes - Attributes object of the fragment node
- * @param {string} attributes.public - Denotes the public fragemnt. Headers are not forward in this case
+ * @param {string} attributes.public - Denotes the public fragment.
  * @param {Object} request - HTTP Request object
  * @param {Object} request.headers - request header object
  * @returns {Object} New filtered header object
  */
-module.exports = ({ public: publicFragment }, { headers = {} }) =>
-    publicFragment
+module.exports = (attributes, request) => {
+    const { public: publicFragment } = attributes;
+    const { headers = {} } = request;
+    // Headers are not forwarded to public fragment for security reasons
+    return publicFragment
         ? {}
         : ACCEPT_HEADERS.reduce((newHeaders, key) => {
             headers[key] && (newHeaders[key] = headers[key]);
             return newHeaders;
         }, {});
+};

--- a/lib/filter-headers.js
+++ b/lib/filter-headers.js
@@ -2,15 +2,17 @@
 const ACCEPT_HEADERS = ['accept-language', 'referer', 'user-agent'];
 /**
  * Filter the request headers that are passed to fragment request.
+ * @callback filterHeaders
  *
  * @param {Object} attributes - Attributes object of the fragment node
  * @param {string} attributes.public - Denotes the public fragemnt. Headers are not forward in this case
- * @param {Object} headers - Request header object
+ * @param {Object} request - HTTP Request object
+ * @param {Object} request.headers - request header object
  * @returns {Object} New filtered header object
  */
-module.exports = ({ public: publicFragment }, headers) => 
-    publicFragment 
-        ? {} 
+module.exports = ({ public: publicFragment }, { headers = {} }) =>
+    publicFragment
+        ? {}
         : ACCEPT_HEADERS.reduce((newHeaders, key) => {
             headers[key] && (newHeaders[key] = headers[key]);
             return newHeaders;

--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -43,9 +43,16 @@ module.exports = class Fragment extends EventEmitter {
      * @param {object} context - Context object for the given fragment
      * @param {number} index - Order of the fragment
      * @param {function} requestFragment - Function to request the fragment
-     * @param {string} pipeInstanceName - Pipe instance name generated randomly and used in client side for the layout
+     * @param {string} pipeInstanceName - Pipe instance name that is available in the browser window for consuming hooks
      */
-    constructor (tag, context, index, requestFragment, pipeInstanceName, pipeAttributes) {
+    constructor ({
+        tag,
+        context,
+        index,
+        requestFragment,
+        pipeInstanceName,
+        pipeAttributes = () => {}
+    } = {}) {
         super();
         this.attributes = getAttributes(tag, context, index);
         ['async', 'primary', 'public'].forEach((key) => {
@@ -57,8 +64,7 @@ module.exports = class Fragment extends EventEmitter {
             }
             this.attributes[key] = value;
         });
-        pipeAttributes = pipeAttributes || (() => {});
-        this.pipeAttributes = pipeAttributes(Object.assign({}, {id: index}, tag.attributes));
+        this.pipeAttributes = pipeAttributes(Object.assign({}, { id: index }, tag.attributes));
         this.index = index;
         this.requestFragment = requestFragment;
         this.pipeInstanceName = pipeInstanceName;

--- a/lib/request-fragment.js
+++ b/lib/request-fragment.js
@@ -3,7 +3,6 @@
 const http = require('http');
 const https = require('https');
 const url = require('url');
-const filterHeaders = require('./filter-headers');
 // By default tailor supports gzipped response from fragments
 const requiredHeaders = {
     'accept-encoding': 'gzip, deflate'
@@ -14,35 +13,37 @@ const requiredHeaders = {
  *  - filtered headers
  *  - Specified timeout from fragment attributes
  *
+ * @param {filterHeaders} - Function that handles the header forwarding
  * @param {string} fragmentUrl - URL of the fragment server
  * @param {Object} fragmentAttributes - Attributes passed via fragment tags
  * @param {Object} request - HTTP request stream
  * @returns {Promise} Response from the fragment server
  */
-module.exports = (fragmentUrl, fragmentAttributes, request) =>
-    new Promise((resolve, reject) => {
-        const parsedUrl = url.parse(fragmentUrl);
-        const options = Object.assign({
-            headers: Object.assign(
-                filterHeaders(fragmentAttributes, request.headers),
-                requiredHeaders
-            ),
-            keepAlive: true,
-            timeout: fragmentAttributes.timeout
-        }, parsedUrl);
-        const { protocol: reqProtocol, timeout } = options;
-        const protocol = reqProtocol === 'https:' ? https : http;
-        const fragmentRequest = protocol.request(options);
-        if (timeout) {
-            fragmentRequest.setTimeout(timeout, fragmentRequest.abort);
-        }
-        fragmentRequest.on('response', (response) => {
-            if (response.statusCode >= 500) {
-                reject(new Error('Internal Server Error'));
-            } else {
-                resolve(response);
+module.exports = (filterHeaders = () => ({})) =>
+    (fragmentUrl, fragmentAttributes, request) =>
+        new Promise((resolve, reject) => {
+            const parsedUrl = url.parse(fragmentUrl);
+            const options = Object.assign({
+                headers: Object.assign(
+                    filterHeaders(fragmentAttributes, request),
+                    requiredHeaders
+                ),
+                keepAlive: true,
+                timeout: fragmentAttributes.timeout
+            }, parsedUrl);
+            const { protocol: reqProtocol, timeout } = options;
+            const protocol = reqProtocol === 'https:' ? https : http;
+            const fragmentRequest = protocol.request(options);
+            if (timeout) {
+                fragmentRequest.setTimeout(timeout, fragmentRequest.abort);
             }
+            fragmentRequest.on('response', (response) => {
+                if (response.statusCode >= 500) {
+                    reject(new Error('Internal Server Error'));
+                } else {
+                    resolve(response);
+                }
+            });
+            fragmentRequest.on('error', reject);
+            fragmentRequest.end();
         });
-        fragmentRequest.on('error', reject);
-        fragmentRequest.end();
-    });

--- a/lib/request-fragment.js
+++ b/lib/request-fragment.js
@@ -19,7 +19,7 @@ const requiredHeaders = {
  * @param {Object} request - HTTP request stream
  * @returns {Promise} Response from the fragment server
  */
-module.exports = (filterHeaders = () => ({})) =>
+module.exports = (filterHeaders) =>
     (fragmentUrl, fragmentAttributes, request) =>
         new Promise((resolve, reject) => {
             const parsedUrl = url.parse(fragmentUrl);

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -16,10 +16,9 @@ const { TEMPLATE_NOT_FOUND } = require('./fetch-template');
 module.exports = function processRequest (options, request, response) {
     this.emit('start', request);
 
-    const { fetchContext, fetchTemplate, handleTag, 
+    const { fetchContext, fetchTemplate, handleTag,
             parseTemplate, requestFragment, fragmentTag,
             pipeAttributes, pipeInstanceName, pipeDefinition} = options;
-    const pipeName = pipeInstanceName();
 
     const asyncStream = new AsyncStream();
     const contextPromise = fetchContext(request).catch((err) => {
@@ -46,7 +45,7 @@ module.exports = function processRequest (options, request, response) {
         const resultStream = new StringifierStream((tag) => {
             const { placeholder, name, } = tag;
             if (placeholder === 'pipe') {
-                return pipeDefinition(pipeName);
+                return pipeDefinition(pipeInstanceName);
             }
 
             if (placeholder === 'async') {
@@ -55,14 +54,14 @@ module.exports = function processRequest (options, request, response) {
             }
 
             if (name === fragmentTag) {
-                const fragment = new Fragment(
+                const fragment = new Fragment({
                     tag,
                     context,
-                    index++,
+                    index: index++,
                     requestFragment,
-                    pipeName,
+                    pipeInstanceName,
                     pipeAttributes
-                );
+                });
 
                 FRAGMENT_EVENTS.forEach((eventName) => {
                     fragment.on(eventName, (...args) => {

--- a/tests/filter-headers.js
+++ b/tests/filter-headers.js
@@ -14,11 +14,11 @@ describe('filter-headers', () => {
 
     it('keeps only certain headers', () => {
         const after = {'accept-language': '1', 'referer': '2', 'user-agent': '3'};
-        assert.deepEqual(filterHeaders({}, headers), after);
+        assert.deepEqual(filterHeaders({}, { headers }), after);
     });
 
     it('removes headers if fragment is public', () => {
-        assert.deepEqual(filterHeaders({public: true}, headers), {});
+        assert.deepEqual(filterHeaders({ public: true }, { headers }), {});
     });
 
 });

--- a/tests/fragment.events.js
+++ b/tests/fragment.events.js
@@ -6,14 +6,15 @@ const TAG = {attributes: {src: 'https://fragment'}};
 const TAG_FALLBACK = {attributes: {src: 'https://fragment', 'fallback-src': 'https://fallback-fragment'}};
 const REQUEST = { headers: {} };
 const RESPONSE_HEADERS = {connection: 'close'};
+const filterHeaderFn = () => ({});
 const sinon = require('sinon');
-const requestFragment = require('../lib/request-fragment')();
+const requestFragment = require('../lib/request-fragment');
 const getOptions = (tag) => {
     return {
         tag,
         context: {},
         index: false,
-        requestFragment
+        requestFragment: requestFragment(filterHeaderFn)
     };
 };
 

--- a/tests/request-fragment.js
+++ b/tests/request-fragment.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const requestFragment = require('../lib/request-fragment')();
 const assert = require('assert');
 const nock = require('nock');
+const filterHeaderFn = () => ({});
+const requestFragment = require('../lib/request-fragment')(filterHeaderFn);
 
 describe('requestFragment', () => {
 

--- a/tests/request-fragment.js
+++ b/tests/request-fragment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const requestFragment = require('../lib/request-fragment');
+const requestFragment = require('../lib/request-fragment')();
 const assert = require('assert');
 const nock = require('nock');
 

--- a/tests/tailor.js
+++ b/tests/tailor.js
@@ -45,7 +45,7 @@ describe('Tailor', () => {
                     return Promise.reject(error);
                 }
             },
-            pipeInstanceName: () => 'p',
+            pipeInstanceName: 'p',
             pipeAttributes: (attributes) => {
                 return {
                     id: attributes.id
@@ -303,14 +303,14 @@ describe('Tailor', () => {
             });
 
         mockTemplate
-            .returns('<fragment src="https://fragment/1"></fragment>');
+            .returns('<fragment id="foo" src="https://fragment/1"></fragment>');
 
         getResponse('http://localhost:8080/test').then((response) => {
             assert.equal(response.body,
                 '<html><head></head><body>' +
-                '<script data-pipe>p.start(0, "http://link2", {"id":0})</script>' +
+                '<script data-pipe>p.start(0, "http://link2", {"id":"foo"})</script>' +
                 'hello' +
-                '<script data-pipe>p.end(0, "http://link2", {"id":0})</script>' +
+                '<script data-pipe>p.end(0, "http://link2", {"id":"foo"})</script>' +
                 '</body></html>'
             );
             done();


### PR DESCRIPTION
+ Document new options
+ Allow headers to be configurable before forwarding to fragments
+ refactor fragment options. 

fix #97 #104 