### PR TITLE
fix uglify options to preserve implicit return

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "fix": "eslint . --fix",
     "benchmark": "node perf/benchmark",
-    "prepublish": "uglifyjs src/pipe.js --mangle --compress=negate_iife=false --comments -o src/pipe.min.js"
+    "prepublish": "uglifyjs src/pipe.js --mangle --compress=negate_iife=false,expression=true --comments -o src/pipe.min.js"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
+ fixes #131 

This breaks our `pipe.min.js` and converts the return statement inside IIFE to a block statement. 

Introduced as part of - https://github.com/mishoo/UglifyJS2/pull/1522

Reminds me that we should use `yarn.lock/shrinkwrap.json` to lock down the versioning of deps. 