### PR TITLE
opt out of server push for preloaded resources

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -60,11 +60,11 @@ module.exports = function processRequest (options, request, response) {
             return;
         }
         if (links.stylesheet && links.stylesheet.url) {
-            assetsToPreload += `<${links.stylesheet.url}>; rel="preload"; as="style",`;
+            assetsToPreload += `<${links.stylesheet.url}>; rel="preload"; as="style"; nopush,`;
         }
         if (links['fragment-script'] && links['fragment-script'].url) {
             const crossOrigin = getCrossOriginHeader(links['fragment-script'].url, request.headers.host);
-            assetsToPreload += `<${links['fragment-script'].url}>; rel="preload"; as="script"; ${crossOrigin},`;
+            assetsToPreload += `<${links['fragment-script'].url}>; rel="preload"; as="script"; nopush; ${crossOrigin},`;
         }
     };
 

--- a/tests/tailor.js
+++ b/tests/tailor.js
@@ -770,7 +770,7 @@ describe('Tailor', () => {
             );
 
         getResponse('http://localhost:8080/test').then((response) => {
-            assert.equal(response.headers.link, '<http://primary>; rel="preload"; as="style",<http://primary>; rel="preload"; as="script"; crossorigin,');
+            assert.equal(response.headers.link, '<http://primary>; rel="preload"; as="style"; nopush,<http://primary>; rel="preload"; as="script"; nopush; crossorigin,');
         }).then(done, done);
     });
 
@@ -783,7 +783,7 @@ describe('Tailor', () => {
         mockTemplate.returns('<fragment primary src="http://fragment/"></fragment>');
 
         getResponse('http://localhost:8080/test').then((response) => {
-            assert.equal(response.headers.link, '<http://localhost:8080>; rel="preload"; as="style",<http://localhost:8080>; rel="preload"; as="script"; ,');
+            assert.equal(response.headers.link, '<http://localhost:8080>; rel="preload"; as="style"; nopush,<http://localhost:8080>; rel="preload"; as="script"; nopush; ,');
         }).then(done, done);
     });
 


### PR DESCRIPTION
Disabling the HTTP/2 server push until the day when cache-digests are supported in browsers and all HTTP/2 pushed resources are HTTP cache aware. 

This will also help avoid undesired server behaviour for preloaded resources via `Link` Headers

More details in the SPEC https://w3c.github.io/preload/#server-push-http-2