### PR TITLE
propagate the error properly to tailor errors [fixes #178]

### DIFF
--- a/lib/fetch-template.js
+++ b/lib/fetch-template.js
@@ -23,17 +23,20 @@ class TemplateError extends Error {
 }
 
 /**
- * Promisify the fs.readFile function
+ * Promisify the functions
  */
-const readFileP = promisify(fs.readFile);
+const readFilePromise = promisify(fs.readFile);
+const lstatPromise = promisify(fs.lstat);
 
 /**
  * Read the file from File System
  *
  * @param {string} path
  */
-const readFile = (path) => readFileP(path, 'utf-8')
-    .catch(err => new TemplateError(err));
+const readFile = (path) => readFilePromise(path, 'utf-8')
+    .catch(err => {
+        throw new TemplateError(err);
+    });
 
 /**
  * Returns the template path validating a exactly file or a directory
@@ -45,23 +48,22 @@ const readFile = (path) => readFileP(path, 'utf-8')
  */
 const getTemplatePath = (templatesPath, pathname) =>
     new Promise((resolve, reject) => {
-        fs.lstat(templatesPath, (err, data) => {
-            if (err) {
+        lstatPromise(templatesPath)
+            .then((data) => {
+                let templateStat = {
+                    isFile: data.isFile()
+                };
+
+                if (templateStat.isFile) {
+                    templateStat.path = templatesPath;
+                } else {
+                    templateStat.path = factoryFilePath(templatesPath, pathname);
+                }
+
+                return resolve(templateStat);
+            }, (err) => {
                 return reject(new TemplateError(err));
-            }
-
-            let templateStat = {
-                isFile: data.isFile()
-            };
-
-            if (templateStat.isFile) {
-                templateStat.path = templatesPath;
-            } else {
-                templateStat.path = factoryFilePath(templatesPath, pathname);
-            }
-
-            return resolve(templateStat);
-        });
+            });
     });
 
 /**

--- a/tests/fetch-template.js
+++ b/tests/fetch-template.js
@@ -39,7 +39,7 @@ describe('fetch-template', () => {
                 });
         });
 
-        it('should throw error on wrong file path', () => {
+        it('should throw TEMPLATE_NOT_FOUND error on wrong file path', () => {
             const wrongTemplatePath = path.join(templatePath, 'wrong-template.html');
             return fetchTemplate(wrongTemplatePath)(mockRequest, mockParseTemplate)
                 .catch(err => {
@@ -72,9 +72,9 @@ describe('fetch-template', () => {
                 });
         });
 
-        it('should throw TEMPLATE_NOT_FOUND error for not present template', () => {
-
-            return fetchTemplate('templates')(mockRequest, mockParseTemplate)
+        it('should throw TEMPLATE_NOT_FOUND error for wrong template path', () => {
+            const request = { url : 'http://localhost:8080/unknown' };
+            return fetchTemplate(templatePath)(request, mockParseTemplate)
                 .catch(err => {
                     assert(err.code, 1);
                     assert(err.presentable, 'template not found');


### PR DESCRIPTION
+ Error was not rethrown before back to the fetchTemplate function
+ Added a test case for the missing case.