### PR TITLE
remove uncessary check for parse result

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -186,14 +186,11 @@ module.exports = function processRequest (options, request, response) {
 
         resultStream.once('error', handleError);
 
-        if (Array.isArray(parsedTemplate)) {
-            parsedTemplate.forEach((item) => {
-                resultStream.write(item);
-            });
-            resultStream.end();
-        } else {
-            resultStream.end(parsedTemplate);
-        }
+        parsedTemplate.forEach((item) => {
+            resultStream.write(item);
+        });
+
+        resultStream.end();
     }).catch(err => {
         handleError(err);
     });


### PR DESCRIPTION
+ the serialised parsed template is always an array. 