### PR TITLE
End asyncStream later in the process (before piping)

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -78,6 +78,10 @@ module.exports = function processRequest(options, request, response) {
     } = options;
 
     const asyncStream = new AsyncStream();
+    asyncStream.once('plugged', () => {
+        asyncStream.end();
+    });
+
     const contextPromise = fetchContext(request).catch(err => {
         this.emit('context:error', request, err);
         return {};
@@ -195,9 +199,6 @@ module.exports = function processRequest(options, request, response) {
             });
 
             resultStream.once('finish', () => {
-                // Flush the async stream only after stringifer stream is finished
-                // This guarentees the async fragments are flushed to the client at last
-                asyncStream.end();
                 const statusCode = response.statusCode || 200;
                 if (shouldWriteHead) {
                     shouldWriteHead = false;

--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -22,6 +22,8 @@ module.exports = class StringifierStream extends stream.Transform {
         }
         let st = this.queue.shift();
         if (st instanceof stream) {
+            st.emit('plugged');
+
             st.setMaxListeners(st.getMaxListeners() + 1);
             this.isBusy = true;
 

--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -1,5 +1,6 @@
 'use strict';
 const stream = require('stream');
+const AsyncStream = require('./async-stream');
 
 module.exports = class StringifierStream extends stream.Transform {
     constructor(fn) {
@@ -22,7 +23,9 @@ module.exports = class StringifierStream extends stream.Transform {
         }
         let st = this.queue.shift();
         if (st instanceof stream) {
-            st.emit('plugged');
+            if (st instanceof AsyncStream) {
+                st.emit('plugged');
+            }
 
             st.setMaxListeners(st.getMaxListeners() + 1);
             this.isBusy = true;


### PR DESCRIPTION
Right now asyncStream ends as soon as we stop pushing things to the stringifier stream, which means we can't push things to asyncStream from our customer tags in handleTag.

To support async fragments there we need to end asyncStream later. It seem like proper place would be to end it right before piping it into the resulting stream. I could either do it in the stringifier stream, but though that it'd be better to do via events (`plugged` event).