### PR TITLE
add support for custom performance entries

### DIFF
--- a/src/pipe.js
+++ b/src/pipe.js
@@ -171,6 +171,10 @@
     * custom timing information to performance entries
     */
     function addPerfEntry(name, duration) {
+        // Should not add to entries when Navigation timing is not supported.
+        if (!'timing' in perf) {
+            return;
+        }
         entries.push({
             name: name,
             duration: Number(duration),

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -173,12 +173,12 @@
     function addPerfEntry(name, duration) {
         entries.push({
             name: name,
-            duration: duration,
+            duration: Number(duration),
             entryType: 'tailor',
             startTime: perf.now() || Date.now() - perf.timing.navigationStart
         });
     }
-    // Retrive the added entries from fragments for monitoring purposes
+    // Retrive the added entries from fragments for monitoring
     function getEntries() {
         return entries;
     }

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -4,6 +4,8 @@
     var scripts = doc.getElementsByTagName('script');
     // State to maintain if all fragments on the page are initialized
     var initState = [];
+    // custom performance entries that are reported from fragments
+    var entries = [];
     var noop = function() {};
     // Hooks that will be replaced later on the page
     var hooks = {
@@ -163,6 +165,23 @@
         onloadcssdefined(loadCB);
         return ss;
     }
+    /*
+    * Custom Performance entries that can be added from fragments
+    * Its need because Browsers currently does not allow expose any API to add
+    * custom timing information to performance entries
+    */
+    function addPerfEntry(name, duration) {
+        entries.push({
+            name: name,
+            duration: duration,
+            entryType: 'tailor',
+            startTime: perf.now() || Date.now() - perf.timing.navigationStart
+        });
+    }
+    // Retrive the added entries from fragments for monitoring purposes
+    function getEntries() {
+        return entries;
+    }
 
     function assignHook(hookName) {
         return function(cb) {
@@ -178,6 +197,8 @@
         onStart: assignHook('onStart'),
         onBeforeInit: assignHook('onBeforeInit'),
         onAfterInit: assignHook('onAfterInit'),
-        onDone: assignHook('onDone')
+        onDone: assignHook('onDone'),
+        addPerfEntry: addPerfEntry,
+        getEntries: getEntries
     };
 })(window.document, window.performance);


### PR DESCRIPTION
### What? 

This PR adds the support for fragment teams to add custom metrics that looks similar to [PerformanceEntry](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry) that can be retrieved via tailor in addition to the [hooks](https://github.com/zalando/tailor/blob/master/docs/hooks.md#front-end-hooks) it supports. 

```js
Pipe.addPerfEntry("time-to-meaningful-paint", 2000.00) // done from some fragment on some page

Pipe.getEntries()
// [{
   name: "time-to-meaningful-paint",
   duration: 2000.00,
   entryType: "tailor",
   startTime: // start time relative to navigation start
}]
```

### Why? 

Browsers right now does not expose an API for creating custom PerformanceEntry and make them available on PerformanceTimeline.

#### why not `perfomance.measure`(User Timing)?

+ User Timing - `mark` and `measure` does not allow a way for pushing custom timing information. If you already have a metric and want to pass that information to PerformanceEntry you cannot do that right now with User Timing API. 

#### why not extend PerformanceEntry? 

Even if we hack and extend the PerformanceEntry object, there is no way to retrive the custom entries that are added. 

```js
var customEntry = {};
customEntry.prototype = PerformanceEntry;
customEntry.name = "ttfmp";
customEntry.duration = Number(paint); // custom paint timing
customEntry.entryType = "tailor";
customEntry.startTime = performance.now();


// retrive entries
performance.getEntries(); 
// returns []
```

### Future

There is a existing issue and proposal in w3c web perf group on exposing the API. So once its landed, we can fallback to that or continue to use them for older browsers. 
Issue - https://github.com/w3c/charter-webperf/issues/28
Proposal - https://docs.google.com/document/d/1_zm9JB-Ul_fOtAMnF6yBcmvNL3m4-k4ram4pdMIcIug/