### PR TITLE
Tailor fails to parse template with comments inside

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -52,7 +52,10 @@ module.exports = class Transform {
         const slotMap = new Map([['default', []]]);
         const nodes = treeAdapter.getChildNodes(root);
         nodes.forEach(node => {
-            if (!treeAdapter.isTextNode(node)) {
+            if (
+                !treeAdapter.isTextNode(node) &&
+                !treeAdapter.isCommentNode(node)
+            ) {
                 const { slot = 'default' } = node.attribs;
                 const slotNodes = slotMap.get(slot) || [];
                 const updatedSlotNodes = [...slotNodes, node];

--- a/tests/parse-template.js
+++ b/tests/parse-template.js
@@ -14,4 +14,10 @@ describe('parseTemplate', () => {
             assert(err instanceof Error);
         });
     });
+
+    it('should parse templates with comments inside', done => {
+        parseTempatePartial('<div></div>', '<!-- nice comment -->')
+            .then(() => done())
+            .catch(done);
+    });
 });


### PR DESCRIPTION
For some reason tailor fails to parse templates with HTML comments inside.

Judging by the error message and some snippets in the code, it seem like handling of comments is different from how other tags are processed.

```
     TypeError: Cannot destructure property `slot` of 'undefined' or 'null'.
      at nodes.forEach.node (lib/transform.js:56:51)
      at Array.forEach (<anonymous>)
      at Transform._groupSlots (lib/transform.js:54:15)
      at Transform.applyTransforms (lib/transform.js:32:24)
      at Promise.resolve.then.transform (lib/parse-template.js:19:19)
      at <anonymous>
```