### PR TITLE
Release version 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Tailor Changelog
 
+### 3.4.0
+* Two headers (`x-request-uri` & `x-request-host`) are added to the whitelist along with documentation on how to use them ([#192](https://github.com/zalando/tailor/pull/192))
+
 ### 3.3.0
 * Add API support for custom performance entries([#187](https://github.com/zalando/tailor/pull/187))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tailor",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Tailor assembles a web page from multiple fragments",
   "keywords": [
     "tailor",


### PR DESCRIPTION
* Two headers (`x-request-uri` & `x-request-host`) are added to the whitelist along with documentation on how to use them ([#192](https://github.com/zalando/tailor/pull/192))