### PR TITLE
parse comment tags without error in child templates

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -52,16 +52,13 @@ module.exports = class Transform {
         const slotMap = new Map([['default', []]]);
         const nodes = treeAdapter.getChildNodes(root);
         nodes.forEach(node => {
-            if (
-                !treeAdapter.isTextNode(node) &&
-                !treeAdapter.isCommentNode(node)
-            ) {
-                const { slot = 'default' } = node.attribs;
+            if (!treeAdapter.isTextNode(node)) {
+                const { slot = 'default' } = node.attribs || {};
                 const slotNodes = slotMap.get(slot) || [];
                 const updatedSlotNodes = [...slotNodes, node];
                 slotMap.set(slot, updatedSlotNodes);
                 this._pushText(node.next, updatedSlotNodes);
-                delete node.attribs.slot;
+                node.attribs && delete node.attribs.slot;
             }
         });
         return slotMap;

--- a/tests/parse-template.js
+++ b/tests/parse-template.js
@@ -14,10 +14,4 @@ describe('parseTemplate', () => {
             assert(err instanceof Error);
         });
     });
-
-    it('should parse templates with comments inside', done => {
-        parseTempatePartial('<div></div>', '<!-- nice comment -->')
-            .then(() => done())
-            .catch(done);
-    });
 });

--- a/tests/transform.js
+++ b/tests/transform.js
@@ -46,6 +46,13 @@ describe('Transform', () => {
         assert(slotMap.has('default'));
     });
 
+    it('should put comment tags in default slot', () => {
+        const childTemplate = '<!-- nice comment -->';
+        transformInstance.applyTransforms('', childTemplate);
+        const slotMap = mockSerializer.args[0][1].slotMap;
+        assert(slotMap.has('default'));
+    });
+
     it('should group slots based on slot types for child Templates', () => {
         const childTemplate = `
             <meta slot="head">


### PR DESCRIPTION
+ Parse comments in child templates without error. 
+ Successor #191 