### PR TITLE
Include demo SPA repos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ Go to [http://localhost:8080/index](http://localhost:8080/index) after running t
 
 **Note: Please run the examples with node versions > 6.0.0**
 
+***
+
+Single-page application examples are also available:
+
+* https://github.com/vigneshshanmugam/tailor-spa
+* https://github.com/tsnolan23/tailor-react-spa
+
 ## Benchmark
 
 To start running benchmark execute `npm run benchmark` and wait for couple of seconds to see the results.


### PR DESCRIPTION
The examples provided by default through Tailor are great to get started, but I think linking directly to the SPA examples in the README would be helpful to those looking to dive a bit deeper into more complex and practical usage of Tailor (similar to the techniques used by Zalando in production).

The second of the two example SPAs was built in response to a dependency handling issue (#196)