### PR TITLE
Prioritize the module loader script with link headers

### DIFF
--- a/lib/process-template.js
+++ b/lib/process-template.js
@@ -52,7 +52,7 @@ module.exports = function processTemplate(request, options, context) {
         };
 
         if (placeholder === 'pipe') {
-            return pipeDefinition(pipeInstanceName);
+            return pipeDefinition(pipeInstanceName, request.headers);
         }
 
         if (placeholder === 'async') {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,7 +1,16 @@
 'use strict';
+
 const AsyncStream = require('./streams/async-stream');
-const LinkHeader = require('http-link-header');
 const ContentLengthStream = require('./streams/content-length-stream');
+const { TEMPLATE_NOT_FOUND } = require('./fetch-template');
+const processTemplate = require('./process-template');
+const {
+    getLoaderScript,
+    getFragmentAssetsToPreload,
+    nextIndexGenerator
+} = require('./utils');
+
+// Events emitted by fragments on the template
 const FRAGMENT_EVENTS = [
     'start',
     'response',
@@ -11,54 +20,6 @@ const FRAGMENT_EVENTS = [
     'fallback',
     'warn'
 ];
-const { TEMPLATE_NOT_FOUND } = require('./fetch-template');
-
-const processTemplate = require('./process-template');
-
-const getCrossOriginHeader = (fragmentUrl, host) => {
-    if (host && fragmentUrl.indexOf(`://${host}`) < 0) {
-        return 'crossorigin';
-    }
-    return '';
-};
-
-// Early preloading of primary fragments assets to improve Performance
-const getAssetsToPreload = ({ link }, { headers = {} }) => {
-    let assetsToPreload = [];
-
-    const { refs = [] } = LinkHeader.parse(link);
-    const scriptRefs = refs
-        .filter(ref => ref.rel === 'fragment-script')
-        .map(ref => ref.uri);
-    const styleRefs = refs
-        .filter(ref => ref.rel === 'stylesheet')
-        .map(ref => ref.uri);
-
-    // Handle Server rendered fragments without depending on assets
-    if (!scriptRefs[0] && !styleRefs[0]) {
-        return '';
-    }
-    styleRefs.forEach(uri => {
-        assetsToPreload.push(`<${uri}>; rel="preload"; as="style"; nopush`);
-    });
-    scriptRefs.forEach(uri => {
-        const crossOrigin = getCrossOriginHeader(uri, headers.host);
-        assetsToPreload.push(
-            `<${uri}>; rel="preload"; as="script"; nopush; ${crossOrigin}`
-        );
-    });
-    return assetsToPreload.join(',');
-};
-
-function nextIndexGenerator(initialIndex, step) {
-    let index = initialIndex;
-
-    return () => {
-        let pastIndex = index;
-        index += step;
-        return pastIndex;
-    };
-}
 
 /**
  * Process the HTTP Request to the Tailor Middleware
@@ -74,7 +35,8 @@ module.exports = function processRequest(options, request, response) {
         fetchTemplate,
         parseTemplate,
         filterResponseHeaders,
-        maxAssetLinks
+        maxAssetLinks,
+        amdLoaderUrl
     } = options;
 
     const asyncStream = new AsyncStream();
@@ -142,12 +104,16 @@ module.exports = function processRequest(options, request, response) {
             }
 
             // Make resources early discoverable while processing HTML
-            const preloadAssets = headers.link
-                ? getAssetsToPreload(headers, request)
-                : '';
-            if (preloadAssets !== '') {
-                responseHeaders.link = preloadAssets;
-            }
+            const assetsToPreload = getFragmentAssetsToPreload(
+                headers,
+                request.headers
+            );
+
+            // Loader script must be preloaded before every fragment asset
+            const loaderScript = getLoaderScript(amdLoaderUrl, request.headers);
+            loaderScript !== '' && assetsToPreload.unshift(loaderScript);
+
+            responseHeaders.link = assetsToPreload.join(',');
             this.emit('response', request, statusCode, responseHeaders);
 
             response.writeHead(statusCode, responseHeaders);
@@ -180,8 +146,10 @@ module.exports = function processRequest(options, request, response) {
                 extendedOptions,
                 context
             );
+            let isFragmentFound = false;
 
             resultStream.on('fragment:found', fragment => {
+                isFragmentFound = true;
                 FRAGMENT_EVENTS.forEach(eventName => {
                     fragment.once(eventName, (...args) => {
                         const prefixedName = 'fragment:' + eventName;
@@ -202,7 +170,18 @@ module.exports = function processRequest(options, request, response) {
                 const statusCode = response.statusCode || 200;
                 if (shouldWriteHead) {
                     shouldWriteHead = false;
+                    // Preload the loader script when atleast
+                    // one fragment is present on the page
+                    if (isFragmentFound) {
+                        const loaderScript = getLoaderScript(
+                            amdLoaderUrl,
+                            request.headers
+                        );
+                        loaderScript !== '' &&
+                            (responseHeaders.link = loaderScript);
+                    }
                     this.emit('response', request, statusCode, responseHeaders);
+
                     response.writeHead(statusCode, responseHeaders);
                     resultStream.pipe(contentLengthStream).pipe(response);
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,11 +2,11 @@
 
 const LinkHeader = require('http-link-header');
 
-const getCrossOrigin = (url = '', host) => {
-    if (host && url.indexOf(`://${host}`) < 0) {
-        return 'crossorigin';
+const getCrossOrigin = (url = '', host = '') => {
+    if (url.includes(`://${host}`)) {
+        return '';
     }
-    return '';
+    return 'crossorigin';
 };
 
 const getPreloadAttributes = ({
@@ -14,7 +14,7 @@ const getPreloadAttributes = ({
     host,
     asAttribute,
     corsCheck = false,
-    noPush = true // Disable HTTP/2 Push behaviour for now
+    noPush = true // Disable HTTP/2 Push behaviour until digest spec is implemented by most browsers
 }) => {
     return (
         assetUrl &&

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const LinkHeader = require('http-link-header');
+
+const getCrossOrigin = (url = '', host) => {
+    if (host && url.indexOf(`://${host}`) < 0) {
+        return 'crossorigin';
+    }
+    return '';
+};
+
+const getPreloadAttributes = ({
+    assetUrl,
+    host,
+    asAttribute,
+    corsCheck = false,
+    noPush = true // Disable HTTP/2 Push behaviour for now
+}) => {
+    return (
+        assetUrl &&
+        `<${assetUrl}>; rel="preload"; as="${asAttribute}"; ${noPush
+            ? 'nopush;'
+            : ''} ${corsCheck ? getCrossOrigin(assetUrl, host) : ''}`.trim()
+    );
+};
+
+// Module loader script used by tailor for managing dependency between fragments
+const getLoaderScript = (amdLoaderUrl, { host } = {}) => {
+    if (amdLoaderUrl.startsWith('file://')) {
+        return '';
+    }
+
+    return getPreloadAttributes({
+        assetUrl: amdLoaderUrl,
+        asAttribute: 'script',
+        corsCheck: true,
+        host
+    });
+};
+
+// Early preloading of primary fragments assets to improve Performance
+const getFragmentAssetsToPreload = ({ link = '' }, { host } = {}) => {
+    let assetsToPreload = [];
+
+    const { refs = [] } = LinkHeader.parse(link);
+    const scriptRefs = refs
+        .filter(ref => ref.rel === 'fragment-script')
+        .map(ref => ref.uri);
+    const styleRefs = refs
+        .filter(ref => ref.rel === 'stylesheet')
+        .map(ref => ref.uri);
+
+    // Handle Server rendered fragments without depending on assets
+    if (!scriptRefs[0] && !styleRefs[0]) {
+        return assetsToPreload;
+    }
+
+    for (const uri of styleRefs) {
+        assetsToPreload.push(
+            getPreloadAttributes({
+                assetUrl: uri,
+                asAttribute: 'style'
+            })
+        );
+    }
+
+    for (const uri of scriptRefs) {
+        assetsToPreload.push(
+            getPreloadAttributes({
+                assetUrl: uri,
+                asAttribute: 'script',
+                corsCheck: true,
+                host
+            })
+        );
+    }
+
+    return assetsToPreload;
+};
+
+const nextIndexGenerator = (initialIndex, step) => {
+    let index = initialIndex;
+
+    return () => {
+        let pastIndex = index;
+        index += step;
+        return pastIndex;
+    };
+};
+
+module.exports = {
+    getCrossOrigin,
+    getFragmentAssetsToPreload,
+    getLoaderScript,
+    nextIndexGenerator
+};


### PR DESCRIPTION
+ Fixes #202 

+ While working on this feature, figured out a Chrome bug which causes the module loader script in preload cache to be ignored. 

<img width="809" alt="screen shot 2017-12-14 at 14 38 49" src="https://user-images.githubusercontent.com/3902525/34082260-2110a1d2-e35b-11e7-9a7f-6d3d3b7e2106.png">

Link to the bug - bugs.chromium.org/p/chromium/issues/detail?id=794958

+ With this fix, loader script should be the first to be requested, Check before and after

**Before**
<img width="792" alt="screen shot 2017-12-17 at 18 52 55" src="https://user-images.githubusercontent.com/3902525/34082291-82071886-e35b-11e7-88d0-12bd1a64d9a4.png">


**After**
<img width="785" alt="screen shot 2017-12-17 at 18 51 46" src="https://user-images.githubusercontent.com/3902525/34082279-65ec0c2e-e35b-11e7-98a7-ac7975ef32f9.png">

Works only in prime cache because of the chrome bug. 
