### PR TITLE
add custom api for adding ttfmp from fragments

### DIFF
--- a/src/pipe.js
+++ b/src/pipe.js
@@ -167,7 +167,7 @@
     }
     /*
     * Custom Performance entries that can be added from fragments
-    * Its need because Browsers currently does not allow expose any API to add
+    * It's needed because browsers currently do not expose an API to add
     * custom timing information to performance entries
     */
     function addPerfEntry(name, duration) {
@@ -175,12 +175,20 @@
         if (!'timing' in perf) {
             return;
         }
+        // duplicate entries are not handled to keep the API
+        // similar to PerformanceEntry Object
+        // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry
         entries.push({
             name: name,
             duration: Number(duration),
             entryType: 'tailor',
             startTime: perf.now() || Date.now() - perf.timing.navigationStart
         });
+    }
+    // Unique API that allows fragments to specify the
+    // time to first meaningul paint of the page
+    function addTTFMPEntry(duration) {
+        addPerfEntry('ttfmp', duration);
     }
     // Retrive the added entries from fragments for monitoring
     function getEntries() {
@@ -203,6 +211,7 @@
         onAfterInit: assignHook('onAfterInit'),
         onDone: assignHook('onDone'),
         addPerfEntry: addPerfEntry,
+        addTTFMPEntry: addTTFMPEntry,
         getEntries: getEntries
     };
 })(window.document, window.performance);


### PR DESCRIPTION
## Why? 

+ The previous API for adding performance entries to the page is pretty neat and already helps fragments to add custom timing information at every point of the render phase. But it lacks the uniformity and it will be pretty hard to use it for monitoring or any other purpose since the naming is quite different on every page. 

+ Meaningful paint is different for each page and its hard to measure from tailor since tailor has no context of elements being rendered from fragments. Its best to keep the logic in fragments. 

### Solution

The current API is just a proxy to the old `Pipe.addPerfEntry` 
```js
Pipe.addTTFMPEntry(2000);

Pipe.getEntries()
// [{
    duration: 2000
    ​​entryType: "tailor"
    name: "ttfmp"
    startTime: 67.58
}]
```

+ This API will be used only when primary fragments decide that the page is meaningful and the import part of the page is painted. It can be a Hero element that decides the meaningful paint of the page

+  Calling the API multiple times results in duplicate entries added to the Performance Entry. This is to keep in sync with [PerformanceEntry Object](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)

### Future

+ We could use [Hero Element Timing](https://docs.google.com/document/d/1yRYfYR1DnHtgwC4HRR04ipVVhT1h5gkI6yPmKCgJkyQ/edit#) API to mark the important elements that determine the meaningful paint of the page. 

