### PR TITLE
fix: add null check while lazy rendering

### DIFF
--- a/src/pipe.js
+++ b/src/pipe.js
@@ -51,7 +51,11 @@
     }
 
     function isPromise(obj) {
-        return typeof obj === 'object' && typeof obj.then === 'function';
+        return (
+            obj != null &&
+            typeof obj === 'object' &&
+            typeof obj.then === 'function'
+        );
     }
 
     function doInit(init, node, attributes, index) {


### PR DESCRIPTION
+ if fragment init code returns null, pipe would explode and throw runtime error
+ Thanks to Ingvar Stepanyan - https://twitter.com/RReverser/status/986687943602352128