### PR TITLE
fix: handle parsing & primary error properly

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -23,6 +23,8 @@ const FRAGMENT_EVENTS = [
     'fallback',
     'warn'
 ];
+// Occurs when Template parsing fails/Primary Fragment Errors out
+const INTERNAL_SERVER_ERROR = 'Internal Server Error';
 
 /**
  * Process the HTTP Request to the Tailor Middleware
@@ -97,7 +99,7 @@ module.exports = function processRequest(options, request, response) {
             if (typeof err.presentable === 'string') {
                 response.end(`${err.presentable}`);
             } else {
-                response.end();
+                response.end(INTERNAL_SERVER_ERROR);
             }
             span.finish();
         } else {
@@ -153,7 +155,7 @@ module.exports = function processRequest(options, request, response) {
             this.emit('error', request, err);
             span.setTag(Tags.HTTP_STATUS_CODE, 500);
             response.writeHead(500, responseHeaders);
-            response.end();
+            response.end(INTERNAL_SERVER_ERROR);
         });
     };
 


### PR DESCRIPTION
+ If we respond with a empty message with Content-Type: 'text/html', the browser will throw error stating as **This page isn’t working** losing the original error page. 
+ Now we respond with 500 status code and Internal Server Error as the response when there is a parse error or when there is no fallback provided for primary fragment. 

This is a very old bug and it was introduced when we started supporting fallbacks and I noticed after we started the Opentracing instrumentation, so Thanks to @lmineiro  😄 