### PR TITLE
refactor(opentracing): add tests and pass correct span contexts

### DIFF
--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -86,7 +86,7 @@ module.exports = class Fragment extends EventEmitter {
      * @param {object} parentSpan - opentracing Span that will be the parent of the current operation
      * @returns {object} Fragment response streams in case of synchronous fragment or buffer in case of async fragment
      */
-    fetch(request, isFallback, parentSpan = null) {
+    fetch(request, isFallback = false, parentSpan = null) {
         if (!isFallback) {
             this.emit('start');
         }
@@ -97,43 +97,41 @@ module.exports = class Fragment extends EventEmitter {
         const spanOptions = parentSpan ? { childOf: parentSpan } : {};
         const span = tracer.startSpan('fetch-fragment', spanOptions);
         span.addTags({
-            'fragment-url': url,
-            'fragment-id': this.attributes.id || 'unnamed',
+            [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+            url: url,
+            id: this.attributes.id || 'unnamed',
             fallback: isFallback,
             primary: this.attributes.primary,
             async: this.attributes.async,
-            public: this.attributes.public,
-            [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT
+            public: this.attributes.public
         });
-        this.requestFragment(url, this.attributes, request, span)
-            .then(
-                res => this.onResponse(res, isFallback),
-                err => {
-                    if (!isFallback) {
-                        const { fallbackUrl } = this.attributes;
-                        if (fallbackUrl) {
-                            this.emit('fallback', err);
-                            this.fetch(request, true, span);
-                        } else {
-                            this.emit('error', err);
-                            span.setTag(Tags.ERROR, true);
-                            span.log({
-                                message: err.message,
-                                stack: err.stack
-                            });
-                            this.stream.end();
-                        }
+
+        this.requestFragment(url, this.attributes, request, span).then(
+            res => this.onResponse(res, isFallback, span),
+            err => {
+                if (!isFallback) {
+                    const { fallbackUrl } = this.attributes;
+                    if (fallbackUrl) {
+                        this.emit('fallback', err);
+                        this.fetch(request, true, span);
                     } else {
                         span.setTag(Tags.ERROR, true);
                         span.log({
-                            message: err.message,
-                            stack: err.stack
+                            message: err.message
                         });
+                        this.emit('error', err);
                         this.stream.end();
                     }
+                } else {
+                    span.setTag(Tags.ERROR, true);
+                    span.log({
+                        message: err.message
+                    });
+                    this.stream.end();
                 }
-            )
-            .then(() => span.finish());
+                span.finish();
+            }
+        );
         // Async fragments are piped later on the page
         if (this.attributes.async) {
             return Buffer.from(
@@ -147,9 +145,10 @@ module.exports = class Fragment extends EventEmitter {
     /**
      * Handle the fragment response
      * @param {object} response - HTTP response stream from fragment
-     * @param {boolean} isFallback - decides between response from fragment or fallback URL
+     * @param {boolean} isFallback - decides between response from fragment src or fallback src
+     * @param {object} span - fetch-fragment opentracing span
      */
-    onResponse(response, isFallback) {
+    onResponse(response, isFallback, span) {
         const { statusCode, headers } = response;
 
         if (!isFallback) {
@@ -180,6 +179,7 @@ module.exports = class Fragment extends EventEmitter {
         contentLengthStream.on('end', () => {
             this.insertEnd();
             this.stream.end();
+            span.finish();
         });
 
         const handleError = err => {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -83,8 +83,7 @@ module.exports = function processRequest(options, request, response) {
         this.emit('error', request, err);
         span.setTag(Tags.ERROR, true);
         span.log({
-            message: err.message,
-            stack: err.stack
+            message: err.message
         });
         if (shouldWriteHead) {
             shouldWriteHead = false;
@@ -153,9 +152,13 @@ module.exports = function processRequest(options, request, response) {
 
         fragment.once('error', err => {
             this.emit('error', request, err);
-            span.setTag(Tags.HTTP_STATUS_CODE, 500);
+            span.addTags({
+                [Tags.ERROR]: true,
+                [Tags.HTTP_STATUS_CODE]: 500
+            });
             response.writeHead(500, responseHeaders);
             response.end(INTERNAL_SERVER_ERROR);
+            span.finish();
         });
     };
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -83,7 +83,8 @@ module.exports = function processRequest(options, request, response) {
         this.emit('error', request, err);
         span.setTag(Tags.ERROR, true);
         span.log({
-            message: err.message
+            message: err.message,
+            stack: err.stack
         });
         if (shouldWriteHead) {
             shouldWriteHead = false;
@@ -155,6 +156,10 @@ module.exports = function processRequest(options, request, response) {
             span.addTags({
                 [Tags.ERROR]: true,
                 [Tags.HTTP_STATUS_CODE]: 500
+            });
+            span.log({
+                message: err.message,
+                stack: err.stack
             });
             response.writeHead(500, responseHeaders);
             response.end(INTERNAL_SERVER_ERROR);

--- a/tests/fragment.events.js
+++ b/tests/fragment.events.js
@@ -1,7 +1,10 @@
 'use strict';
-const Fragment = require('../lib/fragment');
 const assert = require('assert');
 const nock = require('nock');
+const sinon = require('sinon');
+const Fragment = require('../lib/fragment');
+const requestFragment = require('../lib/request-fragment');
+
 const TAG = { attributes: { src: 'https://fragment' } };
 const TAG_FALLBACK = {
     attributes: {
@@ -12,8 +15,6 @@ const TAG_FALLBACK = {
 const REQUEST = { headers: {} };
 const RESPONSE_HEADERS = { connection: 'close' };
 const filterHeaderFn = () => ({});
-const sinon = require('sinon');
-const requestFragment = require('../lib/request-fragment');
 const getOptions = tag => {
     return {
         tag,
@@ -30,7 +31,7 @@ describe('Fragment events', () => {
             .reply(200, 'OK');
         const fragment = new Fragment(getOptions(TAG));
         fragment.on('start', done);
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
     });
 
     it('triggers `fallback` event', done => {
@@ -44,7 +45,7 @@ describe('Fragment events', () => {
         fragment.on('fallback', () => {
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
     });
 
     it('should not trigger error and response event when fallback is triggered', done => {
@@ -65,7 +66,7 @@ describe('Fragment events', () => {
             assert.equal(onError.callCount, 0);
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
         fragment.stream.resume();
     });
 
@@ -79,7 +80,7 @@ describe('Fragment events', () => {
             assert.deepEqual(headers, RESPONSE_HEADERS);
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
     });
 
     it('triggers `end(contentSize)` when the content is succesfully retreived', done => {
@@ -91,7 +92,7 @@ describe('Fragment events', () => {
             assert.equal(contentSize, 5);
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
         fragment.stream.resume();
     });
 
@@ -104,7 +105,7 @@ describe('Fragment events', () => {
             assert.ok(error);
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
     });
 
     it('should not trigger `response` and `end` for fallback fragment', done => {
@@ -118,7 +119,7 @@ describe('Fragment events', () => {
         fragment.on('response', onResponse);
         fragment.on('end', onEnd);
         fragment.on('fallback', onFallback);
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
         fragment.stream.on('end', () => {
             assert.equal(onResponse.callCount, 0);
             assert.equal(onEnd.callCount, 0);
@@ -139,7 +140,7 @@ describe('Fragment events', () => {
         fragment.on('response', onResponse);
         fragment.on('end', onEnd);
         fragment.on('error', onError);
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
         fragment.stream.on('end', () => {
             assert.equal(onResponse.callCount, 0);
             assert.equal(onEnd.callCount, 0);
@@ -162,7 +163,7 @@ describe('Fragment events', () => {
             assert.equal(error.message, ERROR.message);
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
     });
 
     it('triggers `error(error)` when fragment times out', done => {
@@ -176,6 +177,6 @@ describe('Fragment events', () => {
             assert.equal(err.message, 'socket hang up');
             done();
         });
-        fragment.fetch(REQUEST, false);
+        fragment.fetch(REQUEST);
     });
 });


### PR DESCRIPTION
+ Fix the issue when the parent span(handle-request) was getting finished before the child span(fetch-fragment) is finished. 
+ Add tests for the opentracing instrumentation using [MockTracer](https://opentracing-javascript.surge.sh/classes/mocktracer.html)