### PR TITLE
renamed operation name

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -40,7 +40,7 @@ module.exports = function processRequest(options, request, response) {
         request.headers
     );
     const spanOptions = parentSpanContext ? { childOf: parentSpanContext } : {};
-    const span = tracer.startSpan('handle-request', spanOptions);
+    const span = tracer.startSpan('compose-page', spanOptions);
     span.addTags({
         [Tags.HTTP_URL]: request.url,
         [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER


### PR DESCRIPTION
After giving it some more thought, I believe the most appropriate name for the edge request in Tailor should be `compose-page`.

It follows the rationale that Tailor is a **Composition Service** and the requests it receives are requests aimed at **composing a page**. `compose-page` follows [the conventions](https://github.com/opentracing/specification/blob/master/specification.md#start-a-new-span) that we also have adopted so far - a verb and the object related to such verb.