### PR TITLE
applied opentracing semantic conventions

### DIFF
--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -98,7 +98,7 @@ module.exports = class Fragment extends EventEmitter {
         const span = tracer.startSpan('fetch-fragment', spanOptions);
         span.addTags({
             [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
-            url: url,
+            [Tags.HTTP_URL]: url,
             id: this.attributes.id || 'unnamed',
             fallback: isFallback,
             primary: this.attributes.primary,

--- a/tests/tailor.js
+++ b/tests/tailor.js
@@ -10,7 +10,7 @@ const { TEMPLATE_NOT_FOUND } = require('../lib/fetch-template');
 const Tailor = require('../index');
 const processTemplate = require('../lib/process-template');
 const PIPE_DEFINITION = readFileSync(resolve(__dirname, '../src/pipe.min.js'));
-const { MockTracer } = require('opentracing');
+const { Tags, MockTracer } = require('opentracing');
 
 //Custom mock tracer for Unit tests
 class CustomTracer extends MockTracer {
@@ -1394,7 +1394,7 @@ describe('Tailor', () => {
                     const { tags } = traceResults();
                     assert.deepEqual(tags[1], {
                         'span.kind': 'client',
-                        url: 'https://fragment/1',
+                        [Tags.HTTP_URL]: 'https://fragment/1',
                         id: 'test',
                         fallback: false,
                         primary: false,


### PR DESCRIPTION
Renamed the `url` tag to `http.url`, according to [OpenTracing's semantic conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table)