### PR TITLE
introduce multiple subscribers for on done hook

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,6 +2,10 @@
 
 Tailor provides four hooks on the client side(Browser) that can be used for programmatically measuring Performance.
 
+These hooks does not follow pub sub pattern where we would normally have a number of subscribers listening for the event. The reason being, fragment sripts can have multiple script assets and having more than one subscriber would already make it hard to mark and measure the timing information.
+
+`Pipe.OnDone` is an exception(It does not depend on other hooks) which can be registered multiple times, and they will be executed in the order they are registered.
+
 ## API
 
 ### Pipe.onStart(callback(attributes, index))

--- a/examples/fragment-performance/hooks.js
+++ b/examples/fragment-performance/hooks.js
@@ -113,7 +113,7 @@ async function analyseHooks(mark, measure, entries) {
     /**
      * Performance Measures
      * 3 - timing groups - abovethefold, belowthefold, interactive
-     * 1 - all done
+     * 2 - all done
      * 1- primary fragemnt done
      * 3 including all the fragments
      *  -> Header - 1
@@ -124,7 +124,7 @@ async function analyseHooks(mark, measure, entries) {
      *
      * 3 script tags in Footer fragment
      */
-    assert.equal(measure.length, 10, 'No of measure entries must be 10');
+    assert.equal(measure.length, 11, 'No of measure entries must be 10');
 
     /**
      * No of tailor entries must be three
@@ -184,11 +184,21 @@ async function analyseHooks(mark, measure, entries) {
         'below the fold > above the fold and interactive'
     );
     /**
-     * All done should be the last one to happen
+     * All done happens after all fragemnt exec times are measured
      */
     const allDone = get(measure, 'all-done', 'duration');
 
-    assert(allDone > belowTheFold, 'all done is the last one to happen');
+    assert(allDone > belowTheFold, 'all done must happen after all fragment scripts are executed');
+
+    /**
+     * onDone supports multiple subscribers
+     *
+     * all-done-2 which is measured after all-done should be the
+     * very last thing to happen
+     */
+    const allDone2 = get(measure, 'all-done-2', 'duration');
+
+    assert(allDone2 > allDone, 'all done 2 must happen after all-done');
 
     console.log('Hurray! Metrics tests passed');
 }

--- a/examples/fragment-performance/templates/index.html
+++ b/examples/fragment-performance/templates/index.html
@@ -165,6 +165,9 @@
                  */
                 perf.measure('all-done');
             });
+            Pipe.onDone(() => {
+                perf.measure('all-done-2');
+            });
         })(window.TailorPipe, window.performance);
 
     </script>

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -205,6 +205,18 @@
         };
     }
 
+    /**
+     * Preserve and execute the functions in the order
+     * the callbacks were registered
+     */
+    function onDoneHook(cb) {
+        var prevCb = hooks['onDone'];
+        hooks['onDone'] = function() {
+            prevCb();
+            cb();
+        };
+    }
+
     return {
         placeholder: placeholder,
         start: start,
@@ -213,7 +225,7 @@
         onStart: assignHook('onStart'),
         onBeforeInit: assignHook('onBeforeInit'),
         onAfterInit: assignHook('onAfterInit'),
-        onDone: assignHook('onDone'),
+        onDone: onDoneHook,
         addPerfEntry: addPerfEntry,
         addTTFMPEntry: addTTFMPEntry,
         getEntries: getEntries

--- a/tests/streams/stringifier-stream.js
+++ b/tests/streams/stringifier-stream.js
@@ -11,7 +11,7 @@ function getTemplate(template, specialTags, pipeBeforeTags) {
 }
 
 describe('Stringifier Stream', () => {
-    it('should stream the content from a fragment tag', () => {
+    it('should stream the content from a fragment tag', done => {
         let st = new PassThrough();
         const templatePromise = getTemplate(
             '<fragment title="mock"></fragment>'


### PR DESCRIPTION
+ Having multiple subscribers in onDone performance hook will enable us do post processing of all the metrics and also do reporting in different parts of the application.
+ We do not need multiple subscribers in other hooks since it will make it hard to measure the fragment script exec times. 
+ We are not using pub,sub pattern where we would normally push in to array and call the subscribers, Instead we are chaining the callbacks to make the code simpler and also backwards compatible. 