### PR TITLE
Added index.d.ts to package bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "LICENSE",
     "MAINTAINERS",
     "index.js",
+    "index.d.ts",
     "README.md",
     "src/pipe.min.js",
     "yarn.lock"
-  ]
+  ],
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
As i can see you've a [index.d.ts](https://github.com/zalando/tailor/blob/master/index.d.ts) file in your project source. Unfortunately this file is not shipped in the bundeled package. This pull request will add this file to the bundle and [register the typings](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).