### PR TITLE
Update span names to follow Opentracing conventions

### DIFF
--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -118,7 +118,7 @@ module.exports = class Fragment extends EventEmitter {
             : this.attributes.url;
 
         const spanOptions = parentSpan ? { childOf: parentSpan } : {};
-        const span = tracer.startSpan('fetch-fragment', spanOptions);
+        const span = tracer.startSpan('fetch_fragment', spanOptions);
 
         const {
             id,

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -40,7 +40,7 @@ module.exports = function processRequest(options, request, response) {
         request.headers
     );
     const spanOptions = parentSpanContext ? { childOf: parentSpanContext } : {};
-    const span = tracer.startSpan('compose-page', spanOptions);
+    const span = tracer.startSpan('compose_page', spanOptions);
     span.addTags({
         [Tags.HTTP_URL]: request.url,
         [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER


### PR DESCRIPTION
Updated span name to follow the conventions:
https://github.bus.zalan.do/SRE/opentracing/blob/master/wg-semantic-conventions/best-practices.md