### PR TITLE
(perf) consume streams in parallel and flush them in series

### DIFF
--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -26,7 +26,6 @@ module.exports = class StringifierStream extends stream.Transform {
             if (st instanceof AsyncStream) {
                 st.emit('plugged');
             }
-            st.setMaxListeners(st.getMaxListeners() + 1);
             this.isBusy = true;
 
             /**
@@ -34,7 +33,7 @@ module.exports = class StringifierStream extends stream.Transform {
              * We use the endEmitted flag on the stream to know if the stream has ended
              * before we even register the 'end' event
              */
-            if (st._readableState.endEmitted) {
+            if (st._readableState && st._readableState.endEmitted) {
                 this.onEnd(st);
             } else {
                 st.on('end', () => this.onEnd(st));
@@ -43,6 +42,30 @@ module.exports = class StringifierStream extends stream.Transform {
             this.push(st);
             this.next();
         }
+    }
+
+    onEnd(st) {
+        this.push(Buffer.concat(st.buffer));
+        this.cleanup(st);
+        this.processNext();
+    }
+
+    processNext() {
+        this.isBusy = false;
+        this.next();
+    }
+
+    cleanup(st) {
+        st.buffer = [];
+        st.removeListener('end', () => this.onEnd(st));
+        st.removeListener('error', err => this.onError(err, st));
+        st.setMaxListeners(st.getMaxListeners() - 1);
+    }
+
+    onError(err, st) {
+        this.emit('error', err);
+        this.cleanup(st);
+        this.processNext();
     }
 
     _transform(chunk, encoding, done) {
@@ -59,9 +82,10 @@ module.exports = class StringifierStream extends stream.Transform {
             const st = this.fn(chunk);
             // Consume streams in parallel
             if (st instanceof stream) {
-                st.memoryBuffer = [];
-                const onData = data => st.memoryBuffer.push(data);
+                st.buffer = [];
+                const onData = data => st.buffer.push(data);
 
+                st.setMaxListeners(st.getMaxListeners() + 1);
                 st.on('data', onData);
                 st.on('error', err => this.onError(err, st));
             }
@@ -70,29 +94,6 @@ module.exports = class StringifierStream extends stream.Transform {
         }
         this.next();
         done();
-    }
-
-    onEnd(st) {
-        this.push(Buffer.concat(st.memoryBuffer));
-        this.cleanup(st);
-        this.processNext();
-    }
-
-    processNext() {
-        this.isBusy = false;
-        this.next();
-    }
-
-    cleanup(st) {
-        st.memoryBuffer = [];
-        st.removeListener('end', this.onEnd);
-        st.removeListener('error', this.onError);
-        st.setMaxListeners(st.getMaxListeners() - 1);
-    }
-
-    onError(err, st) {
-        this.emit('error', err);
-        this.cleanup(st);
     }
 
     _flush(done) {

--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -28,6 +28,17 @@ module.exports = class StringifierStream extends stream.Transform {
             }
             st.setMaxListeners(st.getMaxListeners() + 1);
             this.isBusy = true;
+
+            /**
+             * Since streams are consumed in parallel and processed in series,
+             * We use the endEmitted flag on the stream to know if the stream has ended
+             * before we even register the 'end' event
+             */
+            if (st._readableState.endEmitted) {
+                this.onEnd(st);
+            } else {
+                st.on('end', () => this.onEnd(st));
+            }
         } else {
             this.push(st);
             this.next();
@@ -52,10 +63,9 @@ module.exports = class StringifierStream extends stream.Transform {
                 const onData = data => st.memoryBuffer.push(data);
 
                 st.on('data', onData);
-                st.on('end', () => this.onEnd(st));
                 st.on('error', err => this.onError(err, st));
             }
-            // Process streams in order
+            // Process streams in series
             this.queue.push(st);
         }
         this.next();

--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -26,35 +26,8 @@ module.exports = class StringifierStream extends stream.Transform {
             if (st instanceof AsyncStream) {
                 st.emit('plugged');
             }
-
             st.setMaxListeners(st.getMaxListeners() + 1);
             this.isBusy = true;
-
-            const onData = data => {
-                this.push(data);
-            };
-
-            const onEnd = () => {
-                cleanup();
-                this.isBusy = false;
-                this.next();
-            };
-
-            const onError = err => {
-                this.emit('error', err);
-                onEnd();
-            };
-
-            const cleanup = () => {
-                st.removeListener('data', onData);
-                st.removeListener('end', onEnd);
-                st.removeListener('error', onError);
-                st.setMaxListeners(st.getMaxListeners() - 1);
-            };
-
-            st.on('data', onData);
-            st.on('end', onEnd);
-            st.on('error', onError);
         } else {
             this.push(st);
             this.next();
@@ -72,10 +45,44 @@ module.exports = class StringifierStream extends stream.Transform {
                 );
             }
         } else {
-            this.queue.push(this.fn(chunk));
+            const st = this.fn(chunk);
+            // Consume streams in parallel
+            if (st instanceof stream) {
+                st.memoryBuffer = [];
+                const onData = data => st.memoryBuffer.push(data);
+
+                st.on('data', onData);
+                st.on('end', () => this.onEnd(st));
+                st.on('error', err => this.onError(err, st));
+            }
+            // Process streams in order
+            this.queue.push(st);
         }
         this.next();
         done();
+    }
+
+    onEnd(st) {
+        this.push(Buffer.concat(st.memoryBuffer));
+        this.cleanup(st);
+        this.processNext();
+    }
+
+    processNext() {
+        this.isBusy = false;
+        this.next();
+    }
+
+    cleanup(st) {
+        st.memoryBuffer = [];
+        st.removeListener('end', this.onEnd);
+        st.removeListener('error', this.onError);
+        st.setMaxListeners(st.getMaxListeners() - 1);
+    }
+
+    onError(err, st) {
+        this.emit('error', err);
+        this.cleanup(st);
     }
 
     _flush(done) {

--- a/tests/streams/stringifier-stream.js
+++ b/tests/streams/stringifier-stream.js
@@ -11,29 +11,29 @@ function getTemplate(template, specialTags, pipeBeforeTags) {
 }
 
 describe('Stringifier Stream', () => {
-    let index = 0;
-    const delays = [30, 20, 50];
-    function getDelay() {
-        const currDelay = delays[index];
-        index++;
-        if (index >= delays.length) {
-            index = 0;
-        }
-        return currDelay;
+    function getRandomDelay() {
+        const max = 30;
+        const min = 0;
+        return Math.floor(Math.random() * (max - min + 1)) + min;
     }
 
     function writeDelayedDataToStream(data, stream) {
         const chunks = data.split(' ');
+        setTimeout(() => scheduleChunk(chunks, stream, 0), getRandomDelay());
+    }
 
-        for (let i = 0; i < chunks.length; i++) {
-            setTimeout(() => {
-                if (i === chunks.length - 1) {
-                    stream.end(chunks[i]);
-                } else {
-                    stream.write(chunks[i]);
-                }
-            }, getDelay());
+    function scheduleChunk(chunks, stream, index) {
+        if (index === chunks.length - 1) {
+            stream.end(chunks[index]);
+            return;
+        } else {
+            stream.write(chunks[index]);
         }
+
+        setTimeout(
+            () => scheduleChunk(chunks, stream, index + 1),
+            getRandomDelay()
+        );
     }
 
     it('should stream the content from a fragment tag', done => {
@@ -131,7 +131,7 @@ describe('Stringifier Stream', () => {
             stream.on('end', () => {
                 assert.equal(
                     data,
-                    '<html><head></head><body>fromDataS1fromDataS2fromDataS3</body></html>'
+                    '<html><head></head><body>DatafromS1DatafromS2DatafromS3</body></html>'
                 );
                 done();
             });

--- a/tests/streams/stringifier-stream.js
+++ b/tests/streams/stringifier-stream.js
@@ -43,11 +43,15 @@ describe('Stringifier Stream', () => {
 
     it('should consume stream asynchronously', done => {
         const templatePromise = getTemplate(
-            '<fragment id="1"></fragment><fragment id="2"></fragment>'
+            '<fragment id="1"></fragment><fragment id="2"></fragment><fragment id="3"></fragment>'
         );
         templatePromise.then(nodes => {
             let data = '';
-            let streams = [new PassThrough(), new PassThrough()];
+            let streams = [
+                new PassThrough(),
+                new PassThrough(),
+                new PassThrough()
+            ];
             const stream = new StringifierStream(tag => {
                 if (tag && tag.name) {
                     return streams[tag.attributes.id - 1];
@@ -58,7 +62,10 @@ describe('Stringifier Stream', () => {
                 data += chunk;
             });
             stream.on('end', () => {
-                assert.equal(data, '<html><head></head><body>12</body></html>');
+                assert.equal(
+                    data,
+                    '<html><head></head><body>123</body></html>'
+                );
                 done();
             });
             nodes.forEach(node => stream.write(node));
@@ -66,7 +73,12 @@ describe('Stringifier Stream', () => {
             setTimeout(() => {
                 streams[0].end('1');
             }, 10);
-            streams[1].end('2');
+
+            setTimeout(() => {
+                streams[1].end('2');
+            }, 5);
+
+            streams[2].end('3');
         });
     });
 
@@ -86,7 +98,7 @@ describe('Stringifier Stream', () => {
         getTemplate('<fragment>').then(nodes => {
             let st = new PassThrough();
             let stream = new StringifierStream(tag => {
-                if (tag) {
+                if (tag.name === 'fragment') {
                     return st;
                 }
             });


### PR DESCRIPTION
Previously we were consuming and processing the fragment streams in order they were declared in the template. This PR does the following things

+ Consume the fragment streams on fragment buffer in parallel and process them in series while flushing them in to the client to guarantee the order in which fragments are declared on the page. 

+ This would ideally improve the time to last byte and latency. Check benchmarks below. 


**Note**: One caveat  might be increase in the memory usage of the application since we are buffering the response. We are clearing the buffer once the stream is written to the output stream, But it might be a issue if fragments are sending huge data. We can figure this out and warn by listening on `fragment:response` event which has the size of response


### Benchmarks

In order to show the clear picture of the results, I created a dummy fragment server which creates known delays in producing the response so its easy to compare with before and after the changes

```js
// fragment server code

let index = 0;
const delays = [100, 20, 100, 200, 10, 50, 400, 230, 40, 330, 130, 390, 250, 5];
function getDelay() {
    const currDelay = delays[index];
    index++;
    if (index >= delays.length) {
        index = 0;
    }
    return currDelay;
}

http
    .createServer((request, response) => {
        response.writeHead(200, { 'Content-Type': 'text/html' });
        setTimeout(() => {
            response.end('blah');
        }, getDelay());
    })
    .listen(8081);
```

The following changes are made to reduce the influence of other code in the benchmarks
+ Templates are cached (parsing computation is eliminated)
+ Delays from fragment servers are fixed for both results (consuming in parallel vs consuming in series)
+ 10 fragments were on the page with 7 sync and 3 async fragments to show real use case. 

Ran **load test with 100 req/sec for 30 seconds**

### Before
```
Latencies     [mean, 50, 95, 99, max]  403.800887ms, 404.042432ms, 425.609804ms, 469.933934ms, 558.989092ms

Latencies     [mean, 50, 95, 99, max]  401.960285ms, 403.285618ms, 409.419305ms, 465.813201ms, 669.399815ms

Latencies     [mean, 50, 95, 99, max]  404.582374ms, 403.701531ms, 429.116024ms, 467.322299ms, 587.042424ms
```
### After
```
Latencies     [mean, 50, 95, 99, max]  399.522531ms, 402.666553ms, 406.765565ms, 410.959117ms, 451.260693ms

Latencies     [mean, 50, 95, 99, max]  399.411687ms, 402.191078ms, 406.360312ms, 409.321567ms, 426.356372ms

Latencies     [mean, 50, 95, 99, max]  399.693539ms, 402.11449ms, 407.070213ms, 410.855198ms, 428.636678ms
```

Huge thanks to @watson for the idea 👍  

