### PR TITLE
(fix): handle streams in object mode while buffering

### DIFF
--- a/lib/streams/stringifier-stream.js
+++ b/lib/streams/stringifier-stream.js
@@ -83,7 +83,10 @@ module.exports = class StringifierStream extends stream.Transform {
             // Consume streams in parallel
             if (st instanceof stream) {
                 st.buffer = [];
-                const onData = data => st.buffer.push(data);
+                const onData = data => {
+                    data = data instanceof Buffer ? data : Buffer.from(data);
+                    st.buffer.push(data);
+                };
 
                 st.setMaxListeners(st.getMaxListeners() + 1);
                 st.on('data', onData);

--- a/tests/streams/stringifier-stream.js
+++ b/tests/streams/stringifier-stream.js
@@ -117,7 +117,7 @@ describe('Stringifier Stream', () => {
             let streams = [
                 new PassThrough(),
                 new PassThrough(),
-                new PassThrough()
+                new PassThrough({ objectMode: true })
             ];
             const stream = new StringifierStream(tag => {
                 if (tag && tag.name) {


### PR DESCRIPTION
This is a edge case because stringifier deals only with fragment streams which are not supposed to be in object mode, But using handleTags, we can parse arbitrary tags and send streams in objectMode to the response stream. 

Since [`decodeStrings`](https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options) is set to true for fragment streams, all data will be passed as buffers and Buffer.concat would work well. But on objectMode streams, this will not happen and chunks are not decoded as buffers instead left as [arbitrary data chunks](https://github.com/nodejs/node/blob/master/lib/_stream_writable.js#L338)

This PR handles this case when chunks are not buffers. 

Without this fix, we will see an issue like this, 

```js
Uncaught TypeError [ERR_INVALID_ARG_TYPE]: The "list[0]" argument must be one of type Array, Buffer, or Uint8Array. Received type string
 at Function.concat (buffer.js:479:13)
 at StringifierStream.onEnd (lib/streams/stringifier-stream.js:48:26)
 at StringifierStream.next (lib/streams/stringifier-stream.js:37:22)
 at StringifierStream.next (lib/streams/stringifier-stream.js:43:18)
 at StringifierStream.processNext (lib/streams/stringifier-stream.js:55:14)

```