### PR TITLE
mark span as error on unzip failure

### DIFF
--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -146,17 +146,13 @@ module.exports = class Fragment extends EventEmitter {
                         this.fetch(request, true, span);
                     } else {
                         span.setTag(Tags.ERROR, true);
-                        span.log({
-                            message: err.message
-                        });
+                        span.log({ message: err.message });
                         this.emit('error', err);
                         this.stream.end();
                     }
                 } else {
                     span.setTag(Tags.ERROR, true);
-                    span.log({
-                        message: err.message
-                    });
+                    span.log({ message: err.message });
                     this.stream.end();
                 }
                 span.finish();
@@ -213,6 +209,8 @@ module.exports = class Fragment extends EventEmitter {
 
         const handleError = err => {
             this.emit('warn', err);
+            span.setTag(Tags.ERROR, true);
+            span.log({ message: err.message });
             contentLengthStream.end();
         };
 


### PR DESCRIPTION
+ when error happens during unzipping, its a broken response and it should be marked as error. 