### PR TITLE
fix: requestFragment option type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ declare class Tailor extends EventEmitter {
     , maxAssetLinks?: number
     , pipeAttributes?: (attributes: Attributes) => object
     , pipeInstanceName?: string
-    , requestFragment?: (filterHeaders: (attributes: Attributes, req: IncomingMessage) => object, url: Url, attributes: Attributes, req: IncomingMessage, span?: Span) => Promise<ServerResponse>
+    , requestFragment?: (url: Url, attributes: Attributes, req: IncomingMessage, span?: Span) => Promise<ServerResponse>
     , templatesPath?: string
     , tracer?: Tracer
   })


### PR DESCRIPTION
# Problem

Currently, when trying to create a `requestFragment` handler in typescript, the current type says that I should implement the fragment handler like this:

```ts
import { IncomingMessage } from "http";
import { Url } from "url";

import requestFragmentFn from "node-tailor/lib/request-fragment";

/** had to hardcode these from the index.d.ts since they're not exported */
nterface IAttributes {
  id: string;
  src: string;
  async?: boolean;
  fallbackUrl?: string;
  primary?: boolean;
  public?: boolean;
  [key: string]: any;
}

const handleFragment = (
  /** the types are currently demanding that I should define this filterHeaders */
  filterHeaders: (attributes: IAttributes, req: IncomingMessage) => object,
  fragmentUrl: Url,
  fragmentAttributes: IAttributes,
  request: IncomingMessage,
  span = null,
) => {
  /* imagine some logic here */

  return requestFragmentFn(filterHeaders)(fragmentUrl, fragmentAttributes, request, span);
};

export default handleFragment;
```

```ts
import Tailor from "node-tailor";
import requestFragment from "./handlers/fragment";

const tailor = new Tailor({
  requestFragment,
});
```

which results in problems since the actual call in the source code [is not actually like this](https://github.com/zalando/tailor/blob/master/lib/fragment.js#L142)

This PR fixes it by making it respect the actual implementation usage.