### PR TITLE
fix: fetchTemplate option type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ declare class Tailor extends EventEmitter {
   constructor(options?: {
     amdLoaderUrl?: string
     , fetchContext?: (req: IncomingMessage) => Promise<object>
-    , fetchTemplate?: (templatesPath: string, baseTemplateFn: (path: string) => string) => Promise<any>
+    , fetchTemplate?: (req: IncomingMessage, parseTemplate: ParseTemplateFunction) => Promise<any>
     , filterRequestHeaders?: (attributes: Attributes, req: IncomingMessage) => object
     , filterResponseHeaders?: (attributes: Attributes, res: ServerResponse) => object
     , fragmentTag?: string
@@ -56,5 +56,11 @@ interface Attributes {
   public?: boolean
   [key: string]: any
 }
+
+type ParseTemplateFunction = (handledTags: string[], insertBeforePipeTags: string[]) => (
+  baseTemplate: string,
+  childTemplate: string,
+  fullRendering: boolean,
+) => Promise<any>;
 
 


### PR DESCRIPTION
# Problem

Currently, trying to implement  your own fetchTemplate in typescript respecting the implementation will throw this type error:

```
Type '(request: IncomingMessage, parseTemplate: any) => any' is not assignable to type '(templatesPath: string, baseTemplateFn: (path: string) => string) => Promise<any>'.
```

This pull request fixes the types according to the current implementation, also adding a `ParseTemplateFunction` type