### PR TITLE
Correct requestFragment type and initialisation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ declare class Tailor extends EventEmitter {
     , maxAssetLinks?: number
     , pipeAttributes?: (attributes: Attributes) => object
     , pipeInstanceName?: string
-    , requestFragment?: (filterHeaders: (attributes: Attributes, req: IncomingMessage) => object, url: Url, attributes: Attributes, req: IncomingMessage, span?: Span) => Promise<ServerResponse>
+    , requestFragment?: (url: Url, attributes: Attributes, req: IncomingMessage, span?: Span) => Promise<ServerResponse>
     , templatesPath?: string
     , tracer?: Tracer
   })

--- a/index.js
+++ b/index.js
@@ -72,13 +72,15 @@ module.exports = class Tailor extends EventEmitter {
                 fragmentTag: 'fragment',
                 handledTags: [],
                 handleTag: () => '',
-                requestFragment: requestFragment(filterRequestHeaders),
+                requestFragment,
                 pipeInstanceName: 'Pipe',
                 pipeDefinition: pipeChunk,
                 pipeAttributes: getPipeAttributes
             },
             options
         );
+
+        requestOptions.requestFragment = requestOptions.requestFragment(filterRequestHeaders)
 
         initTracer(options.tracer);
 


### PR DESCRIPTION
This corrects the type definition for requestFragment, which does not match it's implementation. This resolves https://github.com/zalando/tailor/issues/327 and supercedes https://github.com/zalando/tailor/pull/297.

This also correct initialisation of custom `requestFragment` functions, which otherwise are not invoked to close over `filterHeaders`.